### PR TITLE
Extract pre(), post(), and invar() from C code.

### DIFF
--- a/src/vcc.ml
+++ b/src/vcc.ml
@@ -2,10 +2,35 @@ open Core.Std
 open Cil
 open Log
 
+(* non-stupid version of Pretty.doc to string *)
+let string_of_doc = Pretty.sprint ~width:Int.max_value
+
+
 let dump (f : Cil.file) : unit =
   List.iter ~f:(fun g -> match g with
       | Cil.GFun(fd,loc) -> Cil.dumpGlobal Cil.defaultCilPrinter stdout (Cil.GFun(fd,loc));
       | _ -> ()) f.globals
+
+
+class call_visitor (vnames : string list) = object(self)
+  inherit nopCilVisitor
+  method vinst (i : instr) =
+    let _ = match i with
+      | Call(_, Lval(Var(var), _), operand, loc) when List.mem vnames var.vname ->
+          let operand = match operand with
+            | [ o ] -> o
+            | _ -> failwithf "%s: Assertion %s must have exactly one operand" (string_of_doc (Cil.d_loc () loc)) var.vname ()
+          in
+          Log.info "%s: Asserting %s(%s)" (string_of_doc (Cil.d_loc () loc)) var.vname (string_of_doc (Cil.d_exp () operand))
+      | _ -> ()
+    in
+    DoChildren
+end
+
+let visit_calls (f : Cil.file) : unit =
+  let vis = new call_visitor [ "pre"; "post"; "invar" ] in
+  ignore (visitCilFile vis f)
+
 
 let do_preprocess infile_path =
   Log.debug "entering do_compile";
@@ -61,7 +86,7 @@ let command =
           Cabs2cil.doCollapseCallCast := true;
           let preprocessed_path = do_preprocess infile_path in
           let cil = do_parse preprocessed_path in
-          dump cil;
+          visit_calls cil;
 
         (* Catch any unhandled exceptions to suppress the nasty-looking message *)
         with

--- a/test/conditions.c
+++ b/test/conditions.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+int main()
+{
+    // For checking whether we can extract conditions from code
+    int x = 1, y = 1, z = 1;
+    pre(x == y);
+    while (1) {
+        invar(y == z);
+    }
+    post(z == x);
+    return 0;
+}


### PR DESCRIPTION
Sample output:

```
$ ./vcc.native -c test/conditions.c -v
info: conditions.c.i:384: Asserting pre(x == y)
info: conditions.c.i:386: Asserting invar(y == z)
info: conditions.c.i:388: Asserting post(z == x)
```